### PR TITLE
Update for argcomplete version 3.1.6

### DIFF
--- a/cachedcomplete/__init__.py
+++ b/cachedcomplete/__init__.py
@@ -4,15 +4,8 @@ from functools import wraps, WRAPPER_ASSIGNMENTS
 
 from .parser_cache import save_cache, load_cache
 
-if argcomplete.USING_PYTHON2:
-    # Don't override __doc__ with wraps because it's read-only in python2
-    __CLASS_WRAPPER_ASSIGNMENTS = tuple(filter(lambda attr: attr != '__doc__', WRAPPER_ASSIGNMENTS))
 
-    _ARGPARSE_LOCAL_IDENTITY_NAME = 'identity'
-else:
-    __CLASS_WRAPPER_ASSIGNMENTS = WRAPPER_ASSIGNMENTS
-
-    _ARGPARSE_LOCAL_IDENTITY_NAME = 'ArgumentParser.__init__.<locals>.identity'
+_ARGPARSE_LOCAL_IDENTITY_NAME = 'ArgumentParser.__init__.<locals>.identity'
 
 def identity(string):
     '''
@@ -27,7 +20,7 @@ def cached_complation_finder(completion_finder_cls):
     if not issubclass(completion_finder_cls, argcomplete.CompletionFinder):
         raise TypeError("cached_completion_finder can only be used on classes that derive from CompletionFinder")
 
-    @wraps(completion_finder_cls, assigned=__CLASS_WRAPPER_ASSIGNMENTS, updated=())
+    @wraps(completion_finder_cls, assigned=WRAPPER_ASSIGNMENTS, updated=())
     class CachedCompletionFinder(completion_finder_cls):
         @staticmethod
         def __fix_default_type(argument_parser):

--- a/cachedcomplete/main_script.py
+++ b/cachedcomplete/main_script.py
@@ -6,13 +6,7 @@ import re
 import sys
 import shlex
 
-from argcomplete import USING_PYTHON2
 from itertools import chain
-
-if USING_PYTHON2:
-    from pipes import quote
-else:
-    quote = shlex.quote
 
 
 SEARCH_RANGE = 1024
@@ -25,11 +19,7 @@ def _skip_easy_install(filename):
     '''
     import inspect
 
-    # Python3 changed the tuple to an object with named fields.
-    if USING_PYTHON2:
-        main_file_frame = [stack_frame[0] for stack_frame in inspect.stack() if stack_frame[1] == filename][-1]
-    else:
-        main_file_frame = [stack_frame.frame for stack_frame in inspect.stack() if stack_frame.filename == filename][-1]
+    main_file_frame = [stack_frame.frame for stack_frame in inspect.stack() if stack_frame.filename == filename][-1]
 
     return main_file_frame.f_globals.get('__file__', filename)
 
@@ -52,7 +42,7 @@ def _get_info_list(expr):
 
 
 def _expand(filename):
-    return quote(os.path.expanduser(os.path.expandvars(filename)))
+    return shlex.quote(os.path.expanduser(os.path.expandvars(filename)))
 
 
 def get_files_to_hash():

--- a/cachedcomplete/parser_cache.py
+++ b/cachedcomplete/parser_cache.py
@@ -4,17 +4,11 @@ Cache for saving python objects based on source code hashes.
 from __future__ import print_function
 
 import os
+import pickle
 import sys
 import subprocess
-from argcomplete import USING_PYTHON2
 from .main_script import MAIN_FILE_PATH, get_files_to_hash
 from .main_script import exists as main_script_exists
-
-# Use the optimized C version for pickle
-if USING_PYTHON2:
-    import cPickle as pickle
-else:
-    import pickle
 
 
 CACHE_DIR = '/tmp/.cachedcomplete'
@@ -76,11 +70,6 @@ def _calc_hash():
 
     :return: A string.
     '''
-    if USING_PYTHON2:
-        devnull = open(os.devnull, 'w')
-    else:
-        devnull = subprocess.DEVNULL
-
     files = ' '.join(get_files_to_hash())
 
     old_pwd = os.path.abspath(os.curdir)
@@ -90,8 +79,6 @@ def _calc_hash():
 
         return subprocess.check_output(
             r"find {} -type f -\! -name '*.pyc' -print0 | sort -zu | xargs -0 cat | md5sum | awk '{{ print $1 }}'".format(files),
-            shell=True, stderr=devnull).decode().strip()
+            shell=True, stderr=subprocess.DEVNULL).decode().strip()
     finally:
         os.chdir(old_pwd)
-        if USING_PYTHON2:
-            devnull.close()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,2 @@
 ipython==7.16.3
-argcomplete==1.11.1
+argcomplete==3.1.6

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,2 @@
-ipython==7.16.3
+ipython==8.10.0
 argcomplete==3.1.6

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if os.path.exists(README_PATH):
 
 setuptools.setup(
     name='cachedcomplete',
-    version='1.0.4',
+    version='2.0.0',
     url='https://github.com/Roynecro97/cachedcomplete',
     project_urls={
         "Source Code": 'https://github.com/Roynecro97/cachedcomplete'
@@ -21,7 +21,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
-        'argcomplete>=1.11.1'
+        'argcomplete>=3.1.6,<4'
     ],
     packages=setuptools.find_packages(exclude=['test']),
     zip_safe=False,
@@ -35,13 +35,12 @@ setuptools.setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         # 'Programming Language :: Python :: Implementation :: PyPy',
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
`argcomplete` has dropped support for Python 2, `cachedcomplete` does not work with newer versions or `argcomplete` because `argcomplete.USING_PYTHON2` has been removed.